### PR TITLE
[MSOURCES-95] Fix source Jar is re-created even when sources are not changed

### DIFF
--- a/src/it/MSOURCES-95-empty-source-folder/invoker.properties
+++ b/src/it/MSOURCES-95-empty-source-folder/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1=${project.groupId}:${project.artifactId}:${project.version}:jar-no-fork ${project.groupId}:${project.artifactId}:${project.version}:test-jar-no-fork
+invoker.goals.2=${project.groupId}:${project.artifactId}:${project.version}:jar-no-fork ${project.groupId}:${project.artifactId}:${project.version}:test-jar-no-fork

--- a/src/it/MSOURCES-95-empty-source-folder/pom.xml
+++ b/src/it/MSOURCES-95-empty-source-folder/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.source</groupId>
+  <artifactId>empty-source-folder</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test that empty source folder does not mark the jar as outdated</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/MSOURCES-95-empty-source-folder/src/main/java/.gitignore
+++ b/src/it/MSOURCES-95-empty-source-folder/src/main/java/.gitignore
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is added just because git does not support
+# empty directories and we need empty directory for the test.

--- a/src/it/MSOURCES-95-empty-source-folder/src/main/resources/main.properties
+++ b/src/it/MSOURCES-95-empty-source-folder/src/main/resources/main.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+

--- a/src/it/MSOURCES-95-empty-source-folder/src/test/java/.gitignore
+++ b/src/it/MSOURCES-95-empty-source-folder/src/test/java/.gitignore
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is added just because git does not support
+# empty directories and we need empty directory for the test.

--- a/src/it/MSOURCES-95-empty-source-folder/src/test/resources/main.properties
+++ b/src/it/MSOURCES-95-empty-source-folder/src/test/resources/main.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+

--- a/src/it/MSOURCES-95-empty-source-folder/verify.groovy
+++ b/src/it/MSOURCES-95-empty-source-folder/verify.groovy
@@ -1,0 +1,34 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, 'build.log' )
+
+String sourcesJarFileName = 'empty-source-folder-1.0-SNAPSHOT-sources.jar'
+String testSourcesJarFileName = "empty-source-folder-1.0-SNAPSHOT-test-sources.jar"
+
+assert buildLog.exists()
+
+// Make sure the jars are created on the first build
+assert buildLog.text =~ / Building jar: .*${sourcesJarFileName}/
+assert buildLog.text =~ / Building jar: .*${testSourcesJarFileName}/
+
+// Make sure the jars are not re-created on subsequent builds
+assert buildLog.text =~ / Archive .*${sourcesJarFileName} is uptodate/
+assert buildLog.text =~ / Archive .*${testSourcesJarFileName} is uptodate/

--- a/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
@@ -50,7 +50,7 @@ import org.codehaus.plexus.util.FileUtils;
 public abstract class AbstractSourceJarMojo
     extends AbstractMojo
 {
-    private static final String[] DEFAULT_INCLUDES = new String[] { "**/*" };
+    private static final String[] DEFAULT_INCLUDES = new String[] { "**/**" };
 
     private static final String[] DEFAULT_EXCLUDES = new String[] {};
 


### PR DESCRIPTION
If there is an empty source directory (such as generated-sources/annotations for example) the sources Jar will be re-created even if the sources are not changed. The reason is the default include pattern - `**/*`. It does not include the directory itself and if the directory is empty there is no way for Plexus Archiver to know if the archive is up to date (no file or directory to compare with the last modification time of the archive), so it does the safe thing and re-creates the archive.

Change the default includes pattern to `**/**`. That will cause the empty directory itself (generated-sources/annotations in our example) to be considered when checking the last modification date so the
archive will not be re-created if it is up to date. Please note that the change of the pattern will not change what is included in the archive - the directory itself will not be included, only its content.

p.s. This is updated version of #1, but I had to create new pull request as I was not able to update the original.