### PR TITLE
enable build with Maven 4

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,14 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-   
-name: Release Drafter
-on:
-  push:
-    branches:
-      - maven-source-plugin-3.x
-  workflow_dispatch:
 
-jobs:
-  update_release_draft:
-    uses: apache/maven-gh-actions-shared/.github/workflows/release-drafter.yml@v5
+_extends: maven-gh-actions-shared
+tag-template: maven-source-plugin-$RESOLVED_VERSION

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
+    with:
+      maven4-enabled: true


### PR DESCRIPTION
build with Maven 4 in CI, to check if maven-source-plugin 3.x works with Maven 4

and complete the table on https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=406620656#Maven4.0.0GAchecklist-Maven4API