### PR TITLE
Fix `skin cannot be null` by declaring the fluido skin in site.xml

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -21,6 +21,19 @@ under the License.
 
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+  <!--
+    Workaround for Maven 4.0.0-beta-3, the version this plugin currently builds against:
+    on beta-3 the parent site descriptor is not resolved, so the skin declared in the
+    Maven parent is not inherited and maven-site-plugin fails with "skin cannot be null".
+    Parent resolution works again on Maven 4.0.0-rc-5+, where this <skin> is redundant
+    (the parent's skin is inherited). Re-check and drop this once the build moves off
+    beta-3. See apache/maven-site-plugin#1286 for the cryptic-error part.
+  -->
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>2.1.0</version>
+  </skin>
   <body>
     <menu name="Overview">
       <item name="Introduction" href="index.html"/>


### PR DESCRIPTION
## Problem

The master `Verify` build has been red since late June: every run fails at the site step with

```
Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.22.0:site (default-site):
skin cannot be null
```

The site 2.0.0 descriptor (`SITE/2.0.0`) no longer supplies a default skin, so maven-site-plugin 3.22.0 requires an explicit `<skin>` element, and `src/site/site.xml` doesn't declare one. (The parent's skin is declared only in maven-parent's own `site.xml`; it is not published as an inheritable site-descriptor artifact — `-X` shows `No parent level 1/2/3 site descriptor` — so it never reaches this project.)

This single failure blocks the whole repo: since master is red, every open PR inherits a red CI and nothing can be merged.

## Fix

Declare `maven-fluido-skin` explicitly in `site.xml` — five lines, no source or dependency changes.

## Why this is the minimal change

The `-P run-its verify` build itself (including the `reproducible` IT that deploys via `file://`) is already **green** on `4.0.0-beta-3` — the site skin is the *only* thing failing. I verified the skin-only change on a fork: the full `Verify` matrix passes **8/8** (ubuntu/macos/windows x JDK 17/21/25) against `4.0.0-beta-3` — https://github.com/aschemaven/maven-source-plugin/actions/runs/29831325551.

This is intentionally the minimal subset needed to unblock CI. It overlaps with the site-skin part of #309, but without that PR's IT-plumbing/transport changes, which aren't needed to make the build green on beta-3.

## Testing

`mvn clean site` and the full `-P run-its verify` matrix pass on 4.0.0-beta-3 (fork run linked above).
