### PR TITLE
Build against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,4 +27,4 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-build: true
-      maven4-version: '4.0.0-beta-3' # same as in project
+      maven4-version: '4.0.0-rc-6' # the same as used in project

--- a/pom.xml
+++ b/pom.xml
@@ -78,12 +78,10 @@ under the License.
 
   <properties>
     <javaVersion>17</javaVersion>
-    <mavenVersion>4.0.0-beta-3</mavenVersion>
+    <mavenVersion>4.0.0-rc-6</mavenVersion>
 
-    <guiceVersion>6.0.0</guiceVersion>
-    <mavenArchiverVersion>4.0.0-beta-1</mavenArchiverVersion>
+    <mavenArchiverVersion>4.0.0-beta-5</mavenArchiverVersion>
     <mavenPluginPluginVersion>4.0.0-beta-1</mavenPluginPluginVersion>
-    <mavenPluginTestingVersion>4.0.0-beta-1</mavenPluginTestingVersion>
     <mockitoVersion>5.23.0</mockitoVersion>
     <plexusArchiverVersion>4.12.0</plexusArchiverVersion>
     <version.maven-plugin-tools>${mavenPluginPluginVersion}</version.maven-plugin-tools>
@@ -126,13 +124,13 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-meta</artifactId>
+      <artifactId>maven-api-annotations</artifactId>
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.maven</groupId>
+      <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-archiver</artifactId>
       <version>${mavenArchiverVersion}</version>
     </dependency>
@@ -147,27 +145,16 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>org.apache.maven.plugin-testing</groupId>
-      <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>${mavenPluginTestingVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
+      <artifactId>maven-testing</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
     </dependency>
+    <!-- the mojo tests build SourceRoot stubs with org.apache.maven.impl.DefaultSourceRoot -->
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-api-impl</artifactId>
+      <artifactId>maven-impl</artifactId>
       <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject</groupId>
-      <artifactId>guice</artifactId>
-      <version>${guiceVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/it/MSOURCES-140/verify.groovy
+++ b/src/it/MSOURCES-140/verify.groovy
@@ -19,4 +19,4 @@
 
 File buildLog = new File( basedir, 'build.log' )
 
-assert buildLog.text =~ /\[INFO\] Artifact org.apache.maven.its.sources:jar-no-fork:jar:sources:1.0-SNAPSHOT already attached to target" + File.separator + "jar-no-fork-1.0-SNAPSHOT-sources.jar: ignoring same re-attach \(same artifact, same file\)/
+assert buildLog.text =~ /\[INFO\] Artifact org.apache.maven.its.sources:jar-no-fork:jar:sources:1.0-SNAPSHOT already attached to target[\/\\]jar-no-fork-1.0-SNAPSHOT-sources.jar: ignoring same re-attach \(same artifact, same file\)/

--- a/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
@@ -21,7 +21,6 @@ package org.apache.maven.plugins.source;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,19 +28,22 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.maven.api.Artifact;
+import org.apache.maven.api.Language;
+import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Project;
+import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.Session;
+import org.apache.maven.api.SourceRoot;
 import org.apache.maven.api.Type;
 import org.apache.maven.api.di.Inject;
-import org.apache.maven.api.model.Resource;
 import org.apache.maven.api.plugin.Log;
 import org.apache.maven.api.plugin.Mojo;
 import org.apache.maven.api.plugin.MojoException;
 import org.apache.maven.api.plugin.annotations.Parameter;
 import org.apache.maven.api.services.ArtifactManager;
 import org.apache.maven.api.services.ProjectManager;
-import org.apache.maven.archiver.MavenArchiveConfiguration;
-import org.apache.maven.archiver.MavenArchiver;
+import org.apache.maven.shared.archiver.MavenArchiveConfiguration;
+import org.apache.maven.shared.archiver.MavenArchiver;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
@@ -258,10 +260,10 @@ public abstract class AbstractSourceJarMojo implements Mojo {
 
     /**
      * @param p {@link Project} not null
-     * @return the compile or test resources
+     * @return the compile or test resource roots
      * @throws MojoException in case of an error.
      */
-    protected abstract List<Resource> getResources(Project p) throws MojoException;
+    protected abstract List<SourceRoot> getResources(Project p) throws MojoException;
 
     /**
      * @param p {@link Project}
@@ -321,7 +323,7 @@ public abstract class AbstractSourceJarMojo implements Mojo {
             }
 
             if (attach) {
-                Artifact artifact = session.createArtifact(
+                ProducedArtifact artifact = session.createProducedArtifact(
                         project.getGroupId(),
                         project.getArtifactId(),
                         project.getVersion(),
@@ -385,23 +387,23 @@ public abstract class AbstractSourceJarMojo implements Mojo {
         }
 
         // MAPI: this should be taken from the resources plugin
-        for (Resource resource : getResources(project)) {
+        for (SourceRoot resource : getResources(project)) {
 
-            Path sourceDirectory = Paths.get(resource.getDirectory());
+            Path sourceDirectory = resource.directory();
 
             if (!Files.exists(sourceDirectory)) {
                 continue;
             }
 
-            List<String> resourceIncludes = resource.getIncludes();
+            List<String> resourceIncludes = resource.includes();
 
             String[] combinedIncludes = getCombinedIncludes(resourceIncludes);
 
-            List<String> resourceExcludes = resource.getExcludes();
+            List<String> resourceExcludes = resource.excludes();
 
             String[] combinedExcludes = getCombinedExcludes(resourceExcludes);
 
-            String targetPath = resource.getTargetPath();
+            String targetPath = resource.targetPath().map(Path::toString).orElse(null);
             if (targetPath != null) {
                 if (!targetPath.trim().endsWith("/")) {
                     targetPath += "/";
@@ -426,20 +428,12 @@ public abstract class AbstractSourceJarMojo implements Mojo {
         // configure for Reproducible Builds based on outputTimestamp value
         archiver.configureReproducibleBuild(outputTimestamp);
 
-        if (project.getBuild() != null) {
-            List<org.apache.maven.api.model.Resource> resources =
-                    project.getBuild().getResources();
-
-            for (org.apache.maven.api.model.Resource r : resources) {
-                if (r.getDirectory().endsWith("maven-shared-archive-resources")) {
-                    addDirectory(
-                            archiver.getArchiver(),
-                            Paths.get(r.getDirectory()),
-                            getCombinedIncludes(null),
-                            getCombinedExcludes(null));
-                }
-            }
-        }
+        projectManager
+                .getEnabledSourceRoots(project, ProjectScope.MAIN, Language.RESOURCES)
+                .map(SourceRoot::directory)
+                .filter(directory -> directory.endsWith("maven-shared-archive-resources"))
+                .forEach(directory -> addDirectory(
+                        archiver.getArchiver(), directory, getCombinedIncludes(null), getCombinedExcludes(null)));
 
         return archiver;
     }

--- a/src/main/java/org/apache/maven/plugins/source/SourceJarNoForkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/SourceJarNoForkMojo.java
@@ -22,9 +22,10 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.api.Language;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.ProjectScope;
-import org.apache.maven.api.model.Resource;
+import org.apache.maven.api.SourceRoot;
 import org.apache.maven.api.plugin.annotations.Mojo;
 import org.apache.maven.api.plugin.annotations.Parameter;
 
@@ -47,18 +48,23 @@ public class SourceJarNoForkMojo extends AbstractSourceJarMojo {
      * {@inheritDoc}
      */
     protected List<Path> getSources(Project p) {
-        return projectManager.getCompileSourceRoots(p, ProjectScope.MAIN);
+        return projectManager
+                .getEnabledSourceRoots(p, ProjectScope.MAIN, Language.JAVA_FAMILY)
+                .map(SourceRoot::directory)
+                .toList();
     }
 
     /**
      * {@inheritDoc}
      */
-    protected List<Resource> getResources(Project p) {
+    protected List<SourceRoot> getResources(Project p) {
         if (excludeResources) {
             return Collections.emptyList();
         }
 
-        return projectManager.getResources(p, ProjectScope.MAIN);
+        return projectManager
+                .getEnabledSourceRoots(p, ProjectScope.MAIN, Language.RESOURCES)
+                .toList();
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/source/TestSourceJarNoForkMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/TestSourceJarNoForkMojo.java
@@ -22,9 +22,10 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.api.Language;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.ProjectScope;
-import org.apache.maven.api.model.Resource;
+import org.apache.maven.api.SourceRoot;
 import org.apache.maven.api.plugin.annotations.Mojo;
 import org.apache.maven.api.plugin.annotations.Parameter;
 
@@ -47,18 +48,23 @@ public class TestSourceJarNoForkMojo extends AbstractSourceJarMojo {
      * {@inheritDoc}
      */
     protected List<Path> getSources(Project p) {
-        return projectManager.getCompileSourceRoots(p, ProjectScope.TEST);
+        return projectManager
+                .getEnabledSourceRoots(p, ProjectScope.TEST, Language.JAVA_FAMILY)
+                .map(SourceRoot::directory)
+                .toList();
     }
 
     /**
      * {@inheritDoc}
      */
-    protected List<Resource> getResources(Project p) {
+    protected List<SourceRoot> getResources(Project p) {
         if (excludeResources) {
             return Collections.emptyList();
         }
 
-        return projectManager.getResources(p, ProjectScope.TEST);
+        return projectManager
+                .getEnabledSourceRoots(p, ProjectScope.TEST, Language.RESOURCES)
+                .toList();
     }
 
     /**

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -21,19 +21,6 @@ under the License.
 
 <site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
-  <!--
-    Workaround for Maven 4.0.0-beta-3, the version this plugin currently builds against:
-    on beta-3 the parent site descriptor is not resolved, so the skin declared in the
-    Maven parent is not inherited and maven-site-plugin fails with "skin cannot be null".
-    Parent resolution works again on Maven 4.0.0-rc-5+, where this <skin> is redundant
-    (the parent's skin is inherited). Re-check and drop this once the build moves off
-    beta-3. See apache/maven-site-plugin#1286 for the cryptic-error part.
-  -->
-  <skin>
-    <groupId>org.apache.maven.skins</groupId>
-    <artifactId>maven-fluido-skin</artifactId>
-    <version>2.1.0</version>
-  </skin>
   <body>
     <menu name="Overview">
       <item name="Introduction" href="index.html"/>

--- a/src/test/java/org/apache/maven/plugins/source/AbstractSourcePluginTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/source/AbstractSourcePluginTestCase.java
@@ -27,7 +27,7 @@ import java.util.TreeSet;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.apache.maven.testing.plugin.MojoExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/org/apache/maven/plugins/source/SourceJarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/source/SourceJarMojoTest.java
@@ -20,21 +20,23 @@ package org.apache.maven.plugins.source;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.stream.Stream;
 
+import org.apache.maven.api.Language;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.di.Provides;
-import org.apache.maven.api.plugin.testing.Basedir;
-import org.apache.maven.api.plugin.testing.InjectMojo;
-import org.apache.maven.api.plugin.testing.MojoParameter;
-import org.apache.maven.api.plugin.testing.MojoTest;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
 import org.apache.maven.api.services.ProjectManager;
-import org.apache.maven.internal.impl.InternalSession;
+import org.apache.maven.impl.DefaultSourceRoot;
+import org.apache.maven.impl.InternalSession;
+import org.apache.maven.testing.plugin.Basedir;
+import org.apache.maven.testing.plugin.InjectMojo;
+import org.apache.maven.testing.plugin.MojoParameter;
+import org.apache.maven.testing.plugin.MojoTest;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.apache.maven.testing.plugin.MojoExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -182,18 +184,23 @@ public class SourceJarMojoTest extends AbstractSourcePluginTestCase {
         InternalSession session = SessionMock.getMockSession("target/local-repo");
         ProjectManager projectManager = mock(ProjectManager.class);
         when(session.getService(ProjectManager.class)).thenReturn(projectManager);
-        when(projectManager.getCompileSourceRoots(any(), eq(ProjectScope.MAIN))).thenAnswer(iom -> {
-            Project p = iom.getArgument(0, Project.class);
-            return Collections.singletonList(
-                    Paths.get(getBasedir()).resolve(p.getModel().getBuild().getSourceDirectory()));
-        });
-        when(projectManager.getResources(any(), eq(ProjectScope.MAIN))).thenAnswer(iom -> {
-            Project p = iom.getArgument(0, Project.class);
-            return p.getBuild().getResources().stream()
-                    .map(r -> r.withDirectory(
-                            Paths.get(getBasedir()).resolve(r.getDirectory()).toString()))
-                    .toList();
-        });
+        when(projectManager.getEnabledSourceRoots(any(), eq(ProjectScope.MAIN), eq(Language.JAVA_FAMILY)))
+                .thenAnswer(iom -> {
+                    Project p = iom.getArgument(0, Project.class);
+                    // since 4.0.0-rc-x the model no longer carries a default <sourceDirectory>
+                    String sourceDirectory = p.getModel().getBuild().getSourceDirectory();
+                    return Stream.of(new DefaultSourceRoot(
+                            ProjectScope.MAIN,
+                            Language.JAVA_FAMILY,
+                            Paths.get(getBasedir())
+                                    .resolve(sourceDirectory != null ? sourceDirectory : "src/main/java")));
+                });
+        when(projectManager.getEnabledSourceRoots(any(), eq(ProjectScope.MAIN), eq(Language.RESOURCES)))
+                .thenAnswer(iom -> {
+                    Project p = iom.getArgument(0, Project.class);
+                    return p.getBuild().getResources().stream()
+                            .map(r -> new DefaultSourceRoot(Paths.get(getBasedir()), ProjectScope.MAIN, r));
+                });
         return session;
     }
 }

--- a/src/test/java/org/apache/maven/plugins/source/TestSourceJarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/source/TestSourceJarMojoTest.java
@@ -20,21 +20,23 @@ package org.apache.maven.plugins.source;
 
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.stream.Stream;
 
+import org.apache.maven.api.Language;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.di.Provides;
-import org.apache.maven.api.plugin.testing.Basedir;
-import org.apache.maven.api.plugin.testing.InjectMojo;
-import org.apache.maven.api.plugin.testing.MojoParameter;
-import org.apache.maven.api.plugin.testing.MojoTest;
-import org.apache.maven.api.plugin.testing.stubs.SessionMock;
 import org.apache.maven.api.services.ProjectManager;
-import org.apache.maven.internal.impl.InternalSession;
+import org.apache.maven.impl.DefaultSourceRoot;
+import org.apache.maven.impl.InternalSession;
+import org.apache.maven.testing.plugin.Basedir;
+import org.apache.maven.testing.plugin.InjectMojo;
+import org.apache.maven.testing.plugin.MojoParameter;
+import org.apache.maven.testing.plugin.MojoTest;
+import org.apache.maven.testing.plugin.stubs.SessionMock;
 import org.junit.jupiter.api.Test;
 
-import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.apache.maven.testing.plugin.MojoExtension.getBasedir;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -138,18 +140,23 @@ public class TestSourceJarMojoTest extends AbstractSourcePluginTestCase {
         InternalSession session = SessionMock.getMockSession("target/local-repo");
         ProjectManager projectManager = mock(ProjectManager.class);
         when(session.getService(ProjectManager.class)).thenReturn(projectManager);
-        when(projectManager.getCompileSourceRoots(any(), eq(ProjectScope.TEST))).thenAnswer(iom -> {
-            Project p = iom.getArgument(0, Project.class);
-            return Collections.singletonList(
-                    Paths.get(getBasedir()).resolve(p.getModel().getBuild().getTestSourceDirectory()));
-        });
-        when(projectManager.getResources(any(), eq(ProjectScope.TEST))).thenAnswer(iom -> {
-            Project p = iom.getArgument(0, Project.class);
-            return p.getBuild().getTestResources().stream()
-                    .map(r -> r.withDirectory(
-                            Paths.get(getBasedir()).resolve(r.getDirectory()).toString()))
-                    .toList();
-        });
+        when(projectManager.getEnabledSourceRoots(any(), eq(ProjectScope.TEST), eq(Language.JAVA_FAMILY)))
+                .thenAnswer(iom -> {
+                    Project p = iom.getArgument(0, Project.class);
+                    // since 4.0.0-rc-x the model no longer carries a default <testSourceDirectory>
+                    String testSourceDirectory = p.getModel().getBuild().getTestSourceDirectory();
+                    return Stream.of(new DefaultSourceRoot(
+                            ProjectScope.TEST,
+                            Language.JAVA_FAMILY,
+                            Paths.get(getBasedir())
+                                    .resolve(testSourceDirectory != null ? testSourceDirectory : "src/test/java")));
+                });
+        when(projectManager.getEnabledSourceRoots(any(), eq(ProjectScope.TEST), eq(Language.RESOURCES)))
+                .thenAnswer(iom -> {
+                    Project p = iom.getArgument(0, Project.class);
+                    return p.getBuild().getTestResources().stream()
+                            .map(r -> new DefaultSourceRoot(Paths.get(getBasedir()), ProjectScope.TEST, r));
+                });
         return session;
     }
 }


### PR DESCRIPTION
This plugin was still on `4.0.0-beta-3`, the furthest behind of the 4-native plugins, and it is a migration rather than a version bump.

**Dependencies.** `maven-api-meta` and `maven-api-impl` no longer exist; they become `maven-api-annotations` and `org.apache.maven:maven-testing` respectively, matching what maven-jar-plugin already does. `maven-archiver` moved to `org.apache.maven.shared`.

**Source roots.** `ProjectManager.getCompileSourceRoots(project, scope)` and `getResources(project, scope)` are gone; resources and source roots are unified into `SourceRoot`:

| before | after |
|---|---|
| `getCompileSourceRoots(p, MAIN)` | `getEnabledSourceRoots(p, MAIN, Language.JAVA_FAMILY).map(SourceRoot::directory)` |
| `getResources(p, MAIN)` | `getEnabledSourceRoots(p, MAIN, Language.RESOURCES)` |
| `Resource.getDirectory()` | `SourceRoot.directory()` |
| `Resource.getIncludes()` / `getExcludes()` | `SourceRoot.includes()` / `excludes()` |
| `Resource.getTargetPath()` | `SourceRoot.targetPath()` |
| `session.createArtifact(...)` | `session.createProducedArtifact(...)` |

`attachArtifact` now takes a `ProducedArtifact`. The `maven-shared-archive-resources` special case moves onto the same `SourceRoot` stream. Include/exclude and target-path handling are preserved, so which files land in the sources jar should not change.

**site.xml.** The `<skin>` workaround is removed — its own comment said it was only needed on beta-3 and is redundant from rc-5 onwards.

**Verification.** `mvn test`: 10 tests, 0 failures. `mvn verify -Prun-its`: **all 23 ITs pass**.

Getting there needed a second commit. `MSOURCES-140` was failing, and its assertion turned out to be unrunnable: `verify.groovy:22` is a Groovy slashy-string regex containing the literal text `" + File.separator + "` — Java concatenation written inside a regex literal, which a slashy string does not evaluate. It cannot match on any platform. It went unnoticed because `invoker.properties` requires `4.0.0-beta-4+`, so the IT was skipped on the beta-3 this plugin used to build against. The mojo does emit exactly what it looks for:

```
[INFO] Artifact ...:jar-no-fork:jar:sources:1.0-SNAPSHOT already attached to
target/jar-no-fork-1.0-SNAPSHOT-sources.jar: ignoring same re-attach (same artifact, same file)
```

Matching the separator as a character class makes it pass. Kept as its own commit so it can be dropped or split out if you would rather take it separately.

For reference, unmodified `master` cannot run its ITs under rc-6 at all — every mojo invocation dies with `NoSuchMethodError: ProjectManager.getCompileSourceRoots`, so 22 ITs go from failing to passing here.

Two judgement calls worth a reviewer's eye:

- `createArchiver()` looked up `maven-shared-archive-resources` through `project.getBuild().getResources()`, which is deprecated at rc-6. It now goes through `ProjectManager`, which is a superset — it also sees roots registered at runtime by maven-remote-resources-plugin, the very plugin that produces those resources. No test covers this path either way; it is a two-line revert if you prefer a literal translation.
- `getEnabledSourceRoots` requires a `Language`; `JAVA_FAMILY` is used for sources, matching maven-compiler-plugin. It also filters on `enabled()`, which the old call did not. Both look like the intent of the new API, but they are real semantic differences.

`SourceRoot.stringFiltering()` is deliberately *not* wired up: the beta-3 code never read `Resource.getFiltering()`, and honouring it now would change file contents in the jar.

Part of apache/maven#12676.
