### PR TITLE
Fix TestSourceJarMojo execute phase to generate-test-sources

### DIFF
--- a/src/it/test-jar-generate-test-sources/invoker.properties
+++ b/src/it/test-jar-generate-test-sources/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:test-jar

--- a/src/it/test-jar-generate-test-sources/pom.xml
+++ b/src/it/test-jar-generate-test-sources/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its</groupId>
+  <artifactId>test-jar-generate-test-sources</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test for test-jar with generated test sources</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.3</version>
+        <executions>
+          <execution>
+            <id>generate-test-sources</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <tasks>
+                <touch file="target/generated-test-sources/ant/GeneratedTest.java" mkdirs="true" />
+              </tasks>
+              <testSourceRoot>target/generated-test-sources/ant</testSourceRoot>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/test-jar-generate-test-sources/verify.bsh
+++ b/src/it/test-jar-generate-test-sources/verify.bsh
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+
+try
+{
+    File jarFile = new File( basedir, "target/test-jar-generate-test-sources-1.0-SNAPSHOT-test-sources.jar" );
+    System.out.println( "Checking for existence of " + jarFile );
+    if ( !jarFile.isFile() )
+    {
+        System.out.println( "FAILURE! Test sources JAR does not exist." );
+        return false;
+    }
+
+    JarFile jar = new JarFile( jarFile );
+
+    String[] includedEntries = {
+        "META-INF/MANIFEST.MF",
+        "GeneratedTest.java",
+    };
+    for ( String included : includedEntries )
+    {
+        System.out.println( "Checking for existence of " + included );
+        if ( jar.getEntry( included ) == null )
+        {
+            System.out.println( "FAILURE! Expected entry not found: " + included );
+            return false;
+        }
+    }
+
+    System.out.println( "SUCCESS! Generated test sources are included in the test sources JAR." );
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/test-jar-generate-test-sources/verify.bsh
+++ b/src/it/test-jar-generate-test-sources/verify.bsh
@@ -24,7 +24,6 @@ import java.util.jar.*;
 try
 {
     File jarFile = new File( basedir, "target/test-jar-generate-test-sources-1.0-SNAPSHOT-test-sources.jar" );
-    System.out.println( "Checking for existence of " + jarFile );
     if ( !jarFile.isFile() )
     {
         System.out.println( "FAILURE! Test sources JAR does not exist." );
@@ -39,19 +38,16 @@ try
     };
     for ( String included : includedEntries )
     {
-        System.out.println( "Checking for existence of " + included );
         if ( jar.getEntry( included ) == null )
         {
             System.out.println( "FAILURE! Expected entry not found: " + included );
             return false;
         }
     }
-
-    System.out.println( "SUCCESS! Generated test sources are included in the test sources JAR." );
 }
-catch( Throwable t )
+catch( Exception ex )
 {
-    t.printStackTrace();
+    ex.printStackTrace();
     return false;
 }
 

--- a/src/main/java/org/apache/maven/plugins/source/TestSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/TestSourceJarMojo.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.plugin.annotations.Mojo;
  * @since 2.0.3
  */
 @Mojo(name = "test-jar", defaultPhase = "package")
-@Execute(phase = "generate-sources")
+@Execute(phase = "generate-test-sources")
 public class TestSourceJarMojo extends TestSourceJarNoForkMojo {
     // no op
 }

--- a/src/test/java/org/apache/maven/plugins/source/TestSourceJarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/source/TestSourceJarMojoTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.di.Provides;
+import org.apache.maven.api.plugin.annotations.Execute;
 import org.apache.maven.api.plugin.testing.Basedir;
 import org.apache.maven.api.plugin.testing.InjectMojo;
 import org.apache.maven.api.plugin.testing.MojoParameter;
@@ -35,6 +36,7 @@ import org.apache.maven.internal.impl.InternalSession;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -131,6 +133,12 @@ public class TestSourceJarMojoTest extends AbstractSourcePluginTestCase {
             "META-INF/maven/source/maven-source-plugin-test-project-010/pom.xml",
             "META-INF/maven/source/maven-source-plugin-test-project-010/pom" + ".properties"
         });
+    }
+
+    @Test
+    void testExecutePhase() {
+        Execute execute = TestSourceJarMojo.class.getAnnotation(Execute.class);
+        assertEquals("generate-test-sources", execute.phase());
     }
 
     @Provides


### PR DESCRIPTION
Fixes #304

The TestSourceJarMojo was forking to generate-sources instead of generate-test-sources. This caused test sources generated by other plugins in the generate-test-sources phase to not be available when the mojo runs, leading to an empty or incomplete test sources JAR.

## Changes

- Changed @Execute(phase = generate-sources) to @Execute(phase = generate-test-sources) in TestSourceJarMojo.java
- Added unit test testExecutePhase to verify the correct phase is used
- Added integration test test-jar-generate-test-sources to verify the fix works end-to-end

## Unit Test

The test testExecutePhase verifies that TestSourceJarMojo has @Execute(phase = generate-test-sources). The test fails before the fix and passes after.

## Integration Test

The integration test test-jar-generate-test-sources uses maven-antrun-plugin to generate a file in the generate-test-sources phase and verifies it is included in the test sources JAR. Before the fix, the test-jar goal forks to generate-sources, so the antrun execution does not run and the generated file is not in the JAR. After the fix, the test-jar goal forks to generate-test-sources, so the antrun execution runs and the generated file is in the JAR.

Note: The integration test requires Maven 4.0.0-beta-3 to run.