### PR TITLE
Assert the source archive itself is absent in testNoSources

### DIFF
--- a/src/test/java/org/apache/maven/plugins/source/SourceJarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/source/SourceJarMojoTest.java
@@ -109,7 +109,7 @@ public class SourceJarMojoTest extends AbstractSourcePluginTestCase {
         mojo.execute();
 
         // Now make sure that no archive got created
-        final File expectedFile = getTestTargetDir("project-005");
+        final File expectedFile = getSourceArchive(getTestTargetDir("project-005"), "project-005");
         assertFalse(
                 expectedFile.exists(),
                 "Source archive should not have been created[" + expectedFile.getAbsolutePath() + "]");

--- a/src/test/java/org/apache/maven/plugins/source/TestSourceJarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/source/TestSourceJarMojoTest.java
@@ -103,7 +103,7 @@ public class TestSourceJarMojoTest extends AbstractSourcePluginTestCase {
         mojo.execute();
 
         // Now make sure that no archive got created
-        final File expectedFile = getTestTargetDir("project-005");
+        final File expectedFile = getTestSourceArchive(getTestTargetDir("project-005"), "project-005");
         assertFalse(
                 expectedFile.exists(),
                 "Test source archive should not have been created[" + expectedFile.getAbsolutePath() + "]");


### PR DESCRIPTION
Fixes #308

### Problem

Both `testNoSources` cases assert that no archive was produced like this:

```java
final File expectedFile = getTestTargetDir("project-005");
assertFalse(
        expectedFile.exists(),
        "Source archive should not have been created[" + expectedFile.getAbsolutePath() + "]");
```

`getTestTargetDir` returns the project's `target` **directory**, not the artifact. So the assertion never inspects the jar named in its own failure message — it is bound to whether a directory happens to exist rather than to whether the mojo produced an archive. A directory left behind by earlier build scaffolding, or created for unrelated reasons, is enough to change the outcome, and conversely the check cannot notice a stray jar inside a directory that does exist.

### Fix

Assert the specific artifact instead, reusing the helpers already on `AbstractSourcePluginTestCase`:

- `SourceJarMojoTest` → `getSourceArchive(getTestTargetDir("project-005"), "project-005")`
- `TestSourceJarMojoTest` → `getTestSourceArchive(getTestTargetDir("project-005"), "project-005")`

These are the same helpers the positive cases use via `assertSourceArchive` / `assertTestSourceArchive`, so each negative test now checks exactly the path its positive counterpart asserts, and the failure message names the file that was actually examined.

### Testing

`mvn test` — 10 tests across both classes, all passing. Two lines changed, no production code touched.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
