### PR TITLE
Fork test-jar to generate-test-sources

### DIFF
--- a/src/it/test-jar/pom.xml
+++ b/src/it/test-jar/pom.xml
@@ -55,6 +55,19 @@
               <testSourceRoot>target/generated-sources/ant</testSourceRoot>
             </configuration>
           </execution>
+          <execution>
+            <id>generate-test-sources</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <tasks>
+                <touch file="target/generated-sources/ant/generate-test-sources.properties" mkdirs="true" />
+              </tasks>
+              <testSourceRoot>target/generated-sources/ant</testSourceRoot>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/test-jar/verify.bsh
+++ b/src/it/test-jar/verify.bsh
@@ -39,6 +39,7 @@ try
         "MyTest.java",
         "test.properties",
         "generated.properties",
+        "generate-test-sources.properties",
     };
     for ( String included : includedEntries )
     {

--- a/src/main/java/org/apache/maven/plugins/source/TestSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/TestSourceJarMojo.java
@@ -27,7 +27,7 @@ import org.apache.maven.api.plugin.annotations.Mojo;
  * @since 2.0.3
  */
 @Mojo(name = "test-jar", defaultPhase = "package")
-@Execute(phase = "generate-sources")
+@Execute(phase = "generate-test-sources")
 public class TestSourceJarMojo extends TestSourceJarNoForkMojo {
     // no op
 }


### PR DESCRIPTION
Fixes #304

### Problem

`TestSourceJarMojo` packages test sources, but forks only to `generate-sources`:

```java
@Mojo(name = "test-jar", defaultPhase = "package")
@Execute(phase = "generate-sources")
```

Test sources contributed by another plugin bound to `generate-test-sources` do not exist yet when the mojo runs, so they are missing from the test-sources jar. `TestSourceGeneratedJarMojo` packages the same content and already forks to `generate-test-sources`.

### Fix

Fork to `generate-test-sources`. It comes later in the default lifecycle, so everything the previous fork covered is still covered — the change only widens the forked build.

### Testing

The `test-jar` IT only generated sources in `generate-sources`, so it passed either way and did not pin the fork phase. It now also has a `generate-test-sources` execution and asserts that its output reaches the jar, mirroring what the `test-jar-generated` IT already does for `generated-test-jar`.

Against the current `generate-sources` fork the extended IT fails on exactly that entry, with the rest of the jar intact:

```
Checking for existence of META-INF/MANIFEST.MF
Checking for existence of MyTest.java
Checking for existence of test.properties
Checking for existence of generated.properties
Checking for existence of generate-test-sources.properties
FAILURE!
```

The build plan shows the cause — the forked build stops before the new execution:

```
--- init fork of ...:test-jar for ...:test-jar (default-cli) ---
Goal: maven-antrun-plugin:1.3:run (generated-sources)
--- exit fork ---
```

With the fix, `test-jar`, `test-jar-generated`, `test-jar-no-fork` and `test-jar-classifier` all pass, along with the 10 unit tests. Run on Maven 4.0.0-beta-3.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0)
