### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/configureplugin.md.vm
+++ b/src/site/markdown/examples/configureplugin.md.vm
@@ -1,3 +1,10 @@
+---
+title: Configuring Source Plugin
+author: 
+  - Maria Odea Ching
+date: 11 July 2006
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Maria Odea Ching
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Maria Odea Ching
+date: 11 July 2006
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.