### PR TITLE
Warn when the aggregate goal skips a non-pom project

### DIFF
--- a/src/main/java/org/apache/maven/plugins/source/AggregatorSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/AggregatorSourceJarMojo.java
@@ -28,16 +28,23 @@ import org.apache.maven.api.plugin.annotations.Mojo;
  *
  * @since 2.0.3
  */
-@Mojo(name = "aggregate", defaultPhase = "package", aggregator = true)
+@Mojo(name = AggregatorSourceJarMojo.AGGREGATE_GOAL, defaultPhase = "package", aggregator = true)
 @Execute(phase = "generate-sources")
 public class AggregatorSourceJarMojo extends SourceJarMojo {
+
+    static final String AGGREGATE_GOAL = "aggregate";
+
     /**
      * {@inheritDoc}
      */
     @Override
     protected void doExecute() throws MojoException {
-        if (Type.POM.equals(getProject().getPackaging().type().id())) {
+        String packaging = getProject().getPackaging().type().id();
+        if (Type.POM.equals(packaging)) {
             packageSources(reactorProjects);
+        } else {
+            getLog().warn("Not packaging aggregated sources: the " + AGGREGATE_GOAL + " goal requires \"" + Type.POM
+                    + "\" packaging, but this project uses \"" + packaging + "\" packaging.");
         }
     }
 }

--- a/src/test/java/org/apache/maven/plugins/source/AggregatorSourceJarMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/source/AggregatorSourceJarMojoTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.source;
+
+import org.apache.maven.api.Project;
+import org.apache.maven.api.Type;
+import org.apache.maven.api.plugin.Log;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that the aggregate goal reports why it did nothing when the project
+ * does not use "pom" packaging, instead of failing silently.
+ */
+class AggregatorSourceJarMojoTest {
+
+    private AggregatorSourceJarMojo mojoForPackaging(String packaging, Log log) {
+        Project project = mock(Project.class, RETURNS_DEEP_STUBS);
+        when(project.getPackaging().type().id()).thenReturn(packaging);
+
+        AggregatorSourceJarMojo mojo = new AggregatorSourceJarMojo();
+        mojo.project = project;
+        mojo.log = log;
+        return mojo;
+    }
+
+    @Test
+    void warnsWhenPackagingIsNotPom() {
+        Log log = mock(Log.class);
+        AggregatorSourceJarMojo mojo = mojoForPackaging("jar", log);
+
+        mojo.doExecute();
+
+        ArgumentCaptor<CharSequence> message = ArgumentCaptor.forClass(CharSequence.class);
+        verify(log).warn(message.capture());
+
+        String warning = message.getValue().toString();
+        assertTrue(warning.contains("jar"), "warning should name the actual packaging, was: " + warning);
+        assertTrue(warning.contains(Type.POM), "warning should name the required packaging, was: " + warning);
+        assertTrue(
+                warning.contains(AggregatorSourceJarMojo.AGGREGATE_GOAL),
+                "warning should name the goal, was: " + warning);
+    }
+
+    @Test
+    void doesNotWarnWhenPackagingIsPom() {
+        Log log = mock(Log.class);
+        AggregatorSourceJarMojo mojo = mojoForPackaging(Type.POM, log);
+
+        // reactorProjects is left null: packageSources would throw before any warning
+        // is emitted, which is enough to show the non-pom branch was not taken.
+        try {
+            mojo.doExecute();
+        } catch (RuntimeException expected) {
+            // not the subject of this test
+        }
+
+        verify(log, never()).warn(org.mockito.ArgumentMatchers.<CharSequence>any());
+    }
+}


### PR DESCRIPTION
Fixes #306.

## Problem

`AggregatorSourceJarMojo.doExecute()` packages sources only when the project uses `pom` packaging:

```java
if (Type.POM.equals(getProject().getPackaging().type().id())) {
    packageSources(reactorProjects);
}
```

With any other packaging it returns silently. No source JAR is produced and the user gets no indication why — which, as the issue notes, is a plausible outcome of a misleading build or configuration even though `@Mojo(aggregator = true)` normally implies `pom`.

## Change

Adds an `else` branch that logs a warning naming the goal, the required packaging, and the project's actual packaging:

```
[WARNING] Not packaging aggregated sources: the aggregate goal requires "pom"
packaging, but this project uses "jar" packaging.
```

The goal name is now a constant shared by the `@Mojo` annotation and the message, so the two cannot drift apart.

## On warning vs failing

@elharo asked in the issue whether this should fail rather than log. I went with a warning, for the reason discussed there: a non-pom aggregator run **succeeds today**, so failing would turn currently-green builds red without any change on the user's side, and the people most likely to hit it are exactly those with an incidental binding they never noticed. The complaint in the issue is diagnosability, which the warning resolves fully.

If the project would rather treat it as an outright misconfiguration, I am happy to switch this to a failure — I would just suggest tying that to a major version. Say the word and I will push the change.

## Tests

`AggregatorSourceJarMojoTest` adds two cases:

- `warnsWhenPackagingIsNotPom` — asserts the warning is emitted and contains the goal, the required packaging and the actual packaging
- `doesNotWarnWhenPackagingIsPom` — asserts no warning on a legitimate `pom` run, so the change cannot over-correct into warning on valid builds

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

Behaviour for `pom` packaging is unchanged.