### PR TITLE
Add followSymlinks to follow links when jarring sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.13.0</version>
+      <version>4.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/it/jar-follow-symlinks/invoker.properties
+++ b/src/it/jar-follow-symlinks/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Creating a symbolic link needs privileges that are not granted by default on Windows.
+invoker.os.family = !windows

--- a/src/it/jar-follow-symlinks/pom.xml
+++ b/src/it/jar-follow-symlinks/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.source</groupId>
+  <artifactId>jar-follow-symlinks</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test for followSymlinks</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <followSymlinks>true</followSymlinks>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/jar-follow-symlinks/setup.groovy
+++ b/src/it/jar-follow-symlinks/setup.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.Files
+
+// A source directory that is a symbolic link to a tree kept outside src/main/java.
+File link = new File(basedir, 'src/main/java/shared')
+if (Files.isSymbolicLink(link.toPath())) {
+    Files.delete(link.toPath())
+}
+Files.createSymbolicLink(link.toPath(), new File(basedir, 'shared-sources/shared').toPath())
+
+return true

--- a/src/it/jar-follow-symlinks/shared-sources/shared/Shared.java
+++ b/src/it/jar-follow-symlinks/shared-sources/shared/Shared.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package shared;
+
+public class Shared {}

--- a/src/it/jar-follow-symlinks/src/main/java/MyClass.java
+++ b/src/it/jar-follow-symlinks/src/main/java/MyClass.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class MyClass {}

--- a/src/it/jar-follow-symlinks/verify.groovy
+++ b/src/it/jar-follow-symlinks/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+File jar = new File(basedir, 'target/jar-follow-symlinks-1.0-SNAPSHOT-sources.jar')
+assert jar.isFile() : "Missing sources jar $jar"
+
+new ZipFile(jar).withCloseable { zip ->
+    def entry = zip.getEntry('shared/Shared.java')
+    assert entry != null : "shared/Shared.java is missing; entries were ${zip.entries().collect { it.name }}"
+
+    // The link was resolved, so the entry carries the target's source rather than a link path.
+    def text = zip.getInputStream(entry).text
+    assert text.contains('class Shared') : "shared/Shared.java holds $text"
+}
+
+return true

--- a/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
@@ -84,6 +84,16 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
     private boolean useDefaultExcludes;
 
     /**
+     * Whether to follow symbolic links below the source directories. When false, a symbolic link is archived as a
+     * link, which points nowhere once the jar is unpacked somewhere else; when true, a link is archived as the file
+     * or directory it points at, and a linked directory's contents are included.
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "maven.source.followSymlinks", defaultValue = "false")
+    private boolean followSymlinks;
+
+    /**
      * The Maven Project Object
      */
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
@@ -444,7 +454,9 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
             throws MojoExecutionException {
         try {
             getLog().debug("add directory " + sourceDirectory + " to archiver");
-            archiver.addFileSet(DefaultFileSet.fileSet(sourceDirectory).includeExclude(pIncludes, pExcludes));
+            archiver.addFileSet(DefaultFileSet.fileSet(sourceDirectory)
+                    .includeExclude(pIncludes, pExcludes)
+                    .followingSymLinks(followSymlinks));
         } catch (ArchiverException e) {
             throw new MojoExecutionException("Error adding directory to source archive.", e);
         }
@@ -463,8 +475,10 @@ public abstract class AbstractSourceJarMojo extends AbstractMojo {
             throws MojoExecutionException {
         try {
             getLog().debug("add directory " + sourceDirectory + " to archiver with prefix " + prefix);
-            archiver.addFileSet(
-                    DefaultFileSet.fileSet(sourceDirectory).prefixed(prefix).includeExclude(pIncludes, pExcludes));
+            archiver.addFileSet(DefaultFileSet.fileSet(sourceDirectory)
+                    .prefixed(prefix)
+                    .includeExclude(pIncludes, pExcludes)
+                    .followingSymLinks(followSymlinks));
         } catch (ArchiverException e) {
             throw new MojoExecutionException("Error adding directory to source archive.", e);
         }


### PR DESCRIPTION
A symbolic link below a source root was archived as a link, so the sources jar carried an entry pointing outside itself and the linked file was absent. Unpacked anywhere else, the link resolves to nothing. That is [plexus-archiver#160](https://github.com/codehaus-plexus/plexus-archiver/issues/160), open since 2021.

`followSymlinks` (property `maven.source.followSymlinks`) defaults to false, so nothing changes for anyone relying on links being preserved. With it on, a link is archived as the file or directory it points at, and a linked directory's contents are included.

This needs plexus-archiver 4.14.0, which is where `FileSet.isFollowingSymLinks()` arrives ([#481](https://github.com/codehaus-plexus/plexus-archiver/pull/481)) — the pom moves from 4.12.0 to pick it up. The archiver had hardcoded the flag off with no way for a caller to reach it, which is why the 2021 report went nowhere.

Verified: `mvn clean verify -Prun-its` → 10 unit tests and 25/25 ITs, against the released 4.14.0. Removing the wiring makes the new IT fail with the jar holding a bare `shared` entry and no `shared/Shared.java`, which is the reported bug exactly.

The new IT is skipped on Windows — creating a symbolic link there needs privileges that are not granted by default.

Related: MRESOURCES-237 tracks the sibling problem in maven-resources-plugin. Not touched here.

*This change was created with AI assistance.*
