### PR TITLE
Add followSymlinks to follow links when jarring sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ under the License.
     <mavenPluginPluginVersion>4.0.0-beta-2</mavenPluginPluginVersion>
     <mavenPluginTestingVersion>4.0.0-beta-4</mavenPluginTestingVersion>
     <mockitoVersion>5.23.0</mockitoVersion>
-    <plexusArchiverVersion>4.13.0</plexusArchiverVersion>
+    <plexusArchiverVersion>4.14.0</plexusArchiverVersion>
     <version.maven-plugin-tools>${mavenPluginPluginVersion}</version.maven-plugin-tools>
     <project.build.outputTimestamp>2024-06-26T08:31:50Z</project.build.outputTimestamp>
   </properties>

--- a/src/it/jar-follow-symlinks/invoker.properties
+++ b/src/it/jar-follow-symlinks/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Creating a symbolic link needs privileges that are not granted by default on Windows.
+invoker.os.family = !windows

--- a/src/it/jar-follow-symlinks/pom.xml
+++ b/src/it/jar-follow-symlinks/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.source</groupId>
+  <artifactId>jar-follow-symlinks</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test for followSymlinks</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <followSymlinks>true</followSymlinks>
+        </configuration>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/jar-follow-symlinks/setup.groovy
+++ b/src/it/jar-follow-symlinks/setup.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.Files
+
+// A source directory that is a symbolic link to a tree kept outside src/main/java.
+File link = new File(basedir, 'src/main/java/shared')
+if (Files.isSymbolicLink(link.toPath())) {
+    Files.delete(link.toPath())
+}
+Files.createSymbolicLink(link.toPath(), new File(basedir, 'shared-sources/shared').toPath())
+
+return true

--- a/src/it/jar-follow-symlinks/shared-sources/shared/Shared.java
+++ b/src/it/jar-follow-symlinks/shared-sources/shared/Shared.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package shared;
+
+public class Shared {}

--- a/src/it/jar-follow-symlinks/src/main/java/MyClass.java
+++ b/src/it/jar-follow-symlinks/src/main/java/MyClass.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class MyClass {}

--- a/src/it/jar-follow-symlinks/verify.groovy
+++ b/src/it/jar-follow-symlinks/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipFile
+
+File jar = new File(basedir, 'target/jar-follow-symlinks-1.0-SNAPSHOT-sources.jar')
+assert jar.isFile() : "Missing sources jar $jar"
+
+new ZipFile(jar).withCloseable { zip ->
+    def entry = zip.getEntry('shared/Shared.java')
+    assert entry != null : "shared/Shared.java is missing; entries were ${zip.entries().collect { it.name }}"
+
+    // The link was resolved, so the entry carries the target's source rather than a link path.
+    def text = zip.getInputStream(entry).text
+    assert text.contains('class Shared') : "shared/Shared.java holds $text"
+}
+
+return true

--- a/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/source/AbstractSourceJarMojo.java
@@ -88,6 +88,16 @@ public abstract class AbstractSourceJarMojo implements Mojo {
     protected boolean useDefaultExcludes;
 
     /**
+     * Whether to follow symbolic links below the source directories. When false, a symbolic link is archived as a
+     * link, which points nowhere once the jar is unpacked somewhere else; when true, a link is archived as the file
+     * or directory it points at, and a linked directory's contents are included.
+     *
+     * @since 3.5.0
+     */
+    @Parameter(property = "maven.source.followSymlinks", defaultValue = "false")
+    private boolean followSymlinks;
+
+    /**
      * The Maven Project Object
      */
     @Inject
@@ -450,7 +460,9 @@ public abstract class AbstractSourceJarMojo implements Mojo {
             throws MojoException {
         try {
             getLog().debug("add directory " + sourceDirectory + " to archiver");
-            archiver.addFileSet(DefaultFileSet.fileSet(sourceDirectory.toFile()).includeExclude(pIncludes, pExcludes));
+            archiver.addFileSet(DefaultFileSet.fileSet(sourceDirectory.toFile())
+                    .includeExclude(pIncludes, pExcludes)
+                    .followingSymLinks(followSymlinks));
         } catch (ArchiverException e) {
             throw new MojoException("Error adding directory to source archive.", e);
         }
@@ -471,7 +483,8 @@ public abstract class AbstractSourceJarMojo implements Mojo {
             getLog().debug("add directory " + sourceDirectory + " to archiver with prefix " + prefix);
             archiver.addFileSet(DefaultFileSet.fileSet(sourceDirectory.toFile())
                     .prefixed(prefix)
-                    .includeExclude(pIncludes, pExcludes));
+                    .includeExclude(pIncludes, pExcludes)
+                    .followingSymLinks(followSymlinks));
         } catch (ArchiverException e) {
             throw new MojoException("Error adding directory to source archive.", e);
         }


### PR DESCRIPTION
Forward-ports #327 to master.

Same parameter, same default of false. Two conflicts came out of the port: `addDirectory` takes a `Path` on this line, and the archiver version lives in the `${plexusArchiverVersion}` property rather than at the dependency — the property moves 4.12.0 → 4.14.0.

See #327 for the bug ([plexus-archiver#160](https://github.com/codehaus-plexus/plexus-archiver/issues/160)) and for the verification; the ITs there cover the same code.

I have not run this line's ITs locally — the plugin declares prerequisite Maven 4.0.0-rc-6, so they need a Maven 4 to run at all. Leaving that to CI.

*This change was created with AI assistance.*
